### PR TITLE
Enable the `cast_*` clippy option to deny

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_precision_loss)]
+#![deny(clippy::cast_sign_loss)]
+
 mod xxh3;
 
 pub use crate::xxh3::{hash128_with_seed, hash64_with_seed};

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -203,7 +203,7 @@ unsafe fn scramble_accumulators_neon(
     #[cfg(target_arch = "arm")]
     use std::arch::arm::*;
 
-    let prime = vdup_n_u32(PRIME32[0] as u32);
+    let prime = vdup_n_u32(PRIME32[0].try_into().unwrap());
 
     let accum_ptr = accumulators.as_mut_ptr();
     let secret_ptr = secret.as_ptr();
@@ -250,8 +250,8 @@ fn rrmxmx(mut x: u64, y: u64) -> u64 {
 }
 
 fn mul128_and_xor(x: u64, y: u64) -> u64 {
-    let z = (x as u128) * (y as u128);
-    (z as u64) ^ ((z >> 64) as u64)
+    let z = u128::try_from(x).unwrap() * u128::try_from(y).unwrap();
+    u64::try_from(z).unwrap() ^ u64::try_from(z >> 64).unwrap()
 }
 
 fn mix16(data: &[u8], secret: &[u8], seed: u64) -> u64 {
@@ -459,10 +459,10 @@ fn hash64_0(secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = *data.last().unwrap() as u32;
-    let x4 = data.len() as u32;
+    let x1: u32 = data[0].try_into().unwrap();
+    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
+    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
+    let x4: u32 = data.len().try_into().unwrap();
 
     let combined = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
     let mut result = (get_u32(secret, 0) ^ get_u32(secret, 1)) as u64;
@@ -472,7 +472,7 @@ fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u64 {
-    seed ^= ((seed as u32).swap_bytes() as u64) << 32;
+    seed ^= u64::try_from(u32::try_from(seed).unwrap().swap_bytes()).unwrap() << 32;
     let x1 = get_u32(data, 0) as u64;
     let x2 = get_u32(&data[data.len() - 4..], 0) as u64;
     let x = x2 | (x1 << 32);
@@ -595,13 +595,18 @@ fn hash128_0(secret: &[u8], seed: u64) -> u128 {
 }
 
 fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = *data.last().unwrap() as u32;
-    let x4 = data.len() as u32;
+    let x1: u32 = data[0].try_into().unwrap();
+    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
+    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
+    let x4: u32 = data.len().try_into().unwrap();
 
     let combined_low = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
-    let combined_high = (combined_low as u32).swap_bytes().rotate_left(13) as u64;
+    let combined_high: u64 = u32::try_from(combined_low)
+        .unwrap()
+        .swap_bytes()
+        .rotate_left(13)
+        .try_into()
+        .unwrap();
     let s_low = ((get_u32(secret, 0) ^ get_u32(secret, 1)) as u64).wrapping_add(seed);
     let s_high = ((get_u32(secret, 2) ^ get_u32(secret, 3)) as u64).wrapping_sub(seed);
     let high = (xxh64_avalanche(combined_high ^ s_high) as u128) << 64;
@@ -610,7 +615,7 @@ fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
 }
 
 fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
-    seed ^= ((seed as u32).swap_bytes() as u64) << 32;
+    seed ^= u64::try_from(u32::try_from(seed).unwrap().swap_bytes()).unwrap() << 32;
     let x_low = get_u32(data, 0) as u64;
     let x_high = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as u64;
     let x = x_low | (x_high << 32);
@@ -619,8 +624,8 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     let mut y = (x ^ s) as u128;
     y = y.wrapping_mul(PRIME64[0].wrapping_add((data.len() << 2) as u64) as u128);
 
-    let mut r_low = y as u64;
-    let mut r_high = (y >> 64) as u64;
+    let mut r_low: u64 = y.try_into().unwrap();
+    let mut r_high: u64 = (y >> 64).try_into().unwrap();
     r_high = r_high.wrapping_add(r_low << 1);
     r_low ^= r_high >> 3;
     r_low = xorshift(r_low, 35);
@@ -640,7 +645,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     let x_high = x_high ^ s_high;
 
     let result = (mixed as u128).wrapping_mul(PRIME64[0] as u128);
-    let mut r_low = result as u64;
+    let mut r_low: u64 = result.try_into().unwrap();
     let mut r_high = (result >> 64) as u64;
     r_low = r_low.wrapping_add((data.len() as u64 - 1) << 54);
     r_high = r_high.wrapping_add(x_high);
@@ -648,7 +653,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low ^= r_high.swap_bytes();
 
     let result2 = (r_low as u128).wrapping_mul(PRIME64[1] as u128);
-    let mut r2_low = result2 as u64;
+    let mut r2_low: u64 = result2.try_into().unwrap();
     let mut r2_high = (result2 >> 64) as u64;
     r2_high = r2_high.wrapping_add(r_high.wrapping_mul(PRIME64[1]));
     r2_low = xxh3_avalanche(r2_low);


### PR DESCRIPTION
related: <https://github.com/cberner/redb/issues/362>

I don't know if I can clippy::allow only `u128` when the clippy deny option is enabled. First of all, everything has been changed.

I've been working with the following pattern:

1. If type inference is possible, use `try_into`
2. Use `*::try_from` when you need to assign a new variable or assign a type to `TryInto` because it is in the middle of a calculation.