### PR TITLE
Enable the `cast_*` clippy option to deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install packages
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install python3
+          brew install python3 openssl
 
       - name: Install packages
         uses: actions/setup-python@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ authors = ["Christopher Berner <christopherberner@gmail.com>"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = {version = "0.16", features=["extension-module", "abi3-py37"], optional = true }
+pyo3 = {version = "0.17.1", features=["extension-module", "abi3-py37"], optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.3.5", features=["html_reports"] }
+criterion = { version = "0.4.0", features=["html_reports"] }
 rand = "0.8"
 xxhash_reference = { path = "./xxhash_reference" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_precision_loss)]
+#![deny(clippy::cast_sign_loss)]
+
 mod xxh3;
 
 pub use crate::xxh3::{hash128_with_seed, hash64_with_seed};

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -247,7 +247,7 @@ fn rrmxmx(mut x: u64, y: u64) -> u64 {
 }
 
 fn mul128_and_xor(x: u64, y: u64) -> u64 {
-    let z = u128::try_from(x).unwrap() * u128::try_from(y).unwrap();
+    let z = u128::from(x) * u128::from(y);
     #[allow(clippy::cast_possible_truncation)]
     (z as u64 ^ (z >> 64) as u64)
 }
@@ -458,10 +458,11 @@ fn hash64_0(secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
-    let x1: u32 = data[0].try_into().unwrap();
-    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
-    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
-    let x4: u32 = data.len().try_into().unwrap();
+    let x1 = data[0] as u32;
+    let x2 = data[data.len() >> 1] as u32;
+    let x3 = (*data.last().unwrap()) as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let x4 = data.len() as u32;
 
     let combined = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
     let mut result = (get_u32(secret, 0) ^ get_u32(secret, 1)) as u64;
@@ -473,7 +474,7 @@ fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
 fn hash64_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u64 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
-    seed ^= u64::try_from(truncate_seed.swap_bytes()).unwrap() << 32;
+    seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
     let x1 = get_u32(data, 0) as u64;
     let x2 = get_u32(&data[data.len() - 4..], 0) as u64;
     let x = x2 | (x1 << 32);
@@ -596,14 +597,14 @@ fn hash128_0(secret: &[u8], seed: u64) -> u128 {
 }
 
 fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
-    let x1: u32 = data[0].try_into().unwrap();
-    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
-    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
-    let x4: u32 = data.len().try_into().unwrap();
+    let x1 = data[0] as u32;
+    let x2 = data[data.len() >> 1] as u32;
+    let x3 = (*data.last().unwrap()) as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let x4 = data.len() as u32;
 
-    let combined_low = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
-    let combined_high: u64 = u32::try_from(combined_low)
-        .unwrap()
+    let combined_low = (x1 << 16) | (x2 << 24) | x3 | (x4 << 8);
+    let combined_high: u64 = combined_low
         .swap_bytes()
         .rotate_left(13)
         .try_into()
@@ -611,14 +612,14 @@ fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     let s_low = ((get_u32(secret, 0) ^ get_u32(secret, 1)) as u64).wrapping_add(seed);
     let s_high = ((get_u32(secret, 2) ^ get_u32(secret, 3)) as u64).wrapping_sub(seed);
     let high = (xxh64_avalanche(combined_high ^ s_high) as u128) << 64;
-    let low = xxh64_avalanche(combined_low ^ s_low) as u128;
+    let low = xxh64_avalanche(combined_low as u64 ^ s_low) as u128;
     high | low
 }
 
 fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     #[allow(clippy::cast_possible_truncation)]
     let truncate_seed = seed as u32;
-    seed ^= u64::try_from(truncate_seed.swap_bytes()).unwrap() << 32;
+    seed ^= u64::from(truncate_seed.swap_bytes()) << 32;
     let x_low = get_u32(data, 0) as u64;
     let x_high = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as u64;
     let x = x_low | (x_high << 32);

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -88,18 +88,14 @@ pub fn hash128_with_seed(data: &[u8], seed: u64) -> u128 {
         hash128_0to240(data, &DEFAULT_SECRET, seed)
     } else {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            if is_x86_feature_detected!("avx2") {
-                unsafe {
-                    return hash128_large_avx2(data, seed);
-                }
+        if is_x86_feature_detected!("avx2") {
+            unsafe {
+                return hash128_large_avx2(data, seed);
             }
         }
         #[cfg(target_arch = "aarch64")]
-        {
-            unsafe {
-                return hash128_large_neon(data, seed);
-            }
+        unsafe {
+            return hash128_large_neon(data, seed);
         }
         #[cfg(not(target_arch = "aarch64"))]
         hash128_large_generic(
@@ -172,6 +168,7 @@ unsafe fn scramble_accumulators_avx2(
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
 
+    #[allow(clippy::cast_possible_truncation)]
     let simd_prime = _mm256_set1_epi32(PRIME32[0] as i32);
     let secret_ptr = secret.as_ptr();
     let accumulators_ptr = accumulators.as_mut_ptr();
@@ -203,7 +200,7 @@ unsafe fn scramble_accumulators_neon(
     #[cfg(target_arch = "arm")]
     use std::arch::arm::*;
 
-    let prime = vdup_n_u32(PRIME32[0] as u32);
+    let prime = vdup_n_u32(PRIME32[0].try_into().unwrap());
 
     let accum_ptr = accumulators.as_mut_ptr();
     let secret_ptr = secret.as_ptr();
@@ -250,8 +247,9 @@ fn rrmxmx(mut x: u64, y: u64) -> u64 {
 }
 
 fn mul128_and_xor(x: u64, y: u64) -> u64 {
-    let z = (x as u128) * (y as u128);
-    (z as u64) ^ ((z >> 64) as u64)
+    let z = u128::try_from(x).unwrap() * u128::try_from(y).unwrap();
+    #[allow(clippy::cast_possible_truncation)]
+    (z as u64 ^ (z >> 64) as u64)
 }
 
 fn mix16(data: &[u8], secret: &[u8], seed: u64) -> u64 {
@@ -286,6 +284,7 @@ fn gen_secret_generic(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
     secret
 }
 
+#[allow(clippy::cast_possible_truncation)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn gen_secret_avx2(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
@@ -294,12 +293,12 @@ unsafe fn gen_secret_avx2(seed: u64) -> [u8; DEFAULT_SECRET.len()] {
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
 
-    let simd_seed = _mm256_set_epi64x(
-        0u64.wrapping_sub(seed) as i64,
-        seed as i64,
-        0u64.wrapping_sub(seed) as i64,
-        seed as i64,
-    );
+    #[allow(clippy::cast_possible_wrap)]
+    let xxh_i64 = 0u64.wrapping_sub(seed) as i64;
+    #[allow(clippy::cast_possible_wrap)]
+    let seed = seed as i64;
+
+    let simd_seed = _mm256_set_epi64x(xxh_i64, seed, xxh_i64, seed);
 
     let mut output = [0u8; DEFAULT_SECRET.len()];
     let output_ptr = output.as_mut_ptr();
@@ -459,10 +458,10 @@ fn hash64_0(secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = *data.last().unwrap() as u32;
-    let x4 = data.len() as u32;
+    let x1: u32 = data[0].try_into().unwrap();
+    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
+    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
+    let x4: u32 = data.len().try_into().unwrap();
 
     let combined = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
     let mut result = (get_u32(secret, 0) ^ get_u32(secret, 1)) as u64;
@@ -472,7 +471,9 @@ fn hash64_1to3(data: &[u8], secret: &[u8], seed: u64) -> u64 {
 }
 
 fn hash64_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u64 {
-    seed ^= ((seed as u32).swap_bytes() as u64) << 32;
+    #[allow(clippy::cast_possible_truncation)]
+    let truncate_seed = seed as u32;
+    seed ^= u64::try_from(truncate_seed.swap_bytes()).unwrap() << 32;
     let x1 = get_u32(data, 0) as u64;
     let x2 = get_u32(&data[data.len() - 4..], 0) as u64;
     let x = x2 | (x1 << 32);
@@ -595,13 +596,18 @@ fn hash128_0(secret: &[u8], seed: u64) -> u128 {
 }
 
 fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
-    let x1 = data[0] as u32;
-    let x2 = data[data.len() >> 1] as u32;
-    let x3 = *data.last().unwrap() as u32;
-    let x4 = data.len() as u32;
+    let x1: u32 = data[0].try_into().unwrap();
+    let x2: u32 = data[data.len() >> 1].try_into().unwrap();
+    let x3: u32 = (*data.last().unwrap()).try_into().unwrap();
+    let x4: u32 = data.len().try_into().unwrap();
 
     let combined_low = ((x1 << 16) | (x2 << 24) | x3 | (x4 << 8)) as u64;
-    let combined_high = (combined_low as u32).swap_bytes().rotate_left(13) as u64;
+    let combined_high: u64 = u32::try_from(combined_low)
+        .unwrap()
+        .swap_bytes()
+        .rotate_left(13)
+        .try_into()
+        .unwrap();
     let s_low = ((get_u32(secret, 0) ^ get_u32(secret, 1)) as u64).wrapping_add(seed);
     let s_high = ((get_u32(secret, 2) ^ get_u32(secret, 3)) as u64).wrapping_sub(seed);
     let high = (xxh64_avalanche(combined_high ^ s_high) as u128) << 64;
@@ -610,7 +616,9 @@ fn hash128_1to3(data: &[u8], secret: &[u8], seed: u64) -> u128 {
 }
 
 fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
-    seed ^= ((seed as u32).swap_bytes() as u64) << 32;
+    #[allow(clippy::cast_possible_truncation)]
+    let truncate_seed = seed as u32;
+    seed ^= u64::try_from(truncate_seed.swap_bytes()).unwrap() << 32;
     let x_low = get_u32(data, 0) as u64;
     let x_high = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as u64;
     let x = x_low | (x_high << 32);
@@ -619,8 +627,9 @@ fn hash128_4to8(data: &[u8], secret: &[u8], mut seed: u64) -> u128 {
     let mut y = (x ^ s) as u128;
     y = y.wrapping_mul(PRIME64[0].wrapping_add((data.len() << 2) as u64) as u128);
 
+    #[allow(clippy::cast_possible_truncation)]
     let mut r_low = y as u64;
-    let mut r_high = (y >> 64) as u64;
+    let mut r_high: u64 = (y >> 64).try_into().unwrap();
     r_high = r_high.wrapping_add(r_low << 1);
     r_low ^= r_high >> 3;
     r_low = xorshift(r_low, 35);
@@ -640,6 +649,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     let x_high = x_high ^ s_high;
 
     let result = (mixed as u128).wrapping_mul(PRIME64[0] as u128);
+    #[allow(clippy::cast_possible_truncation)]
     let mut r_low = result as u64;
     let mut r_high = (result >> 64) as u64;
     r_low = r_low.wrapping_add((data.len() as u64 - 1) << 54);
@@ -648,6 +658,7 @@ fn hash128_9to16(data: &[u8], secret: &[u8], seed: u64) -> u128 {
     r_low ^= r_high.swap_bytes();
 
     let result2 = (r_low as u128).wrapping_mul(PRIME64[1] as u128);
+    #[allow(clippy::cast_possible_truncation)]
     let mut r2_low = result2 as u64;
     let mut r2_high = (result2 >> 64) as u64;
     r2_high = r2_high.wrapping_add(r_high.wrapping_mul(PRIME64[1]));

--- a/xxhash_reference/Cargo.toml
+++ b/xxhash_reference/Cargo.toml
@@ -11,3 +11,4 @@ libc = "0.2.125"
 
 [build-dependencies]
 cc = "1.0.73"
+cfg-if = "1"

--- a/xxhash_reference/build.rs
+++ b/xxhash_reference/build.rs
@@ -1,6 +1,17 @@
+use cfg_if::cfg_if;
+
 fn main() {
-    cc::Build::new()
-        .file("xxHash/xxhash.c")
-        .flag("-march=native")
-        .compile("xxhash");
+    cfg_if! {
+        if #[cfg(all(target_os = "macos", target_arch = "aarch64"))] {
+            cc::Build::new()
+                .file("xxHash/xxhash.c")
+                .flag("-mcpu=apple-m1")
+                .compile("xxhash");
+        } else {
+            cc::Build::new()
+                .file("xxHash/xxhash.c")
+                .flag("-march=native")
+                .compile("xxhash");
+        }
+    }
 }


### PR DESCRIPTION
1. Enabled with clippy lint option deny for truncation cases during numeric type casting
2. Added `mac m1` compatibility to build scripts of xxh reference crate